### PR TITLE
Fix encoding issues with umlauts

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const monitor = require('./lib/monitor')
 
 const args = process.argv.slice(2)
 
-var stop = args[0]
+var stop = args[0].normalize('NFC')
 var offset = 0
 
 var offsetMatch = args[0].match(/in (\d+)/)

--- a/info.plist
+++ b/info.plist
@@ -39,7 +39,7 @@ Icon by https://icons8.com</string>
 				<key>argumenttype</key>
 				<integer>0</integer>
 				<key>escaping</key>
-				<integer>0</integer>
+				<integer>102</integer>
 				<key>keyword</key>
 				<string>dvb</string>
 				<key>queuedelaycustom</key>
@@ -53,7 +53,7 @@ Icon by https://icons8.com</string>
 				<key>runningsubtext</key>
 				<string>Searching...</string>
 				<key>script</key>
-				<string></string>
+				<string>./index.js `iconv -f UTF8-MAC&lt;&lt;&lt;$1`</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -63,7 +63,7 @@ Icon by https://icons8.com</string>
 				<key>title</key>
 				<string>Monitor a Stop</string>
 				<key>type</key>
-				<integer>8</integer>
+				<integer>0</integer>
 				<key>withspace</key>
 				<true/>
 			</dict>

--- a/info.plist
+++ b/info.plist
@@ -39,7 +39,7 @@ Icon by https://icons8.com</string>
 				<key>argumenttype</key>
 				<integer>0</integer>
 				<key>escaping</key>
-				<integer>102</integer>
+				<integer>0</integer>
 				<key>keyword</key>
 				<string>dvb</string>
 				<key>queuedelaycustom</key>
@@ -53,7 +53,7 @@ Icon by https://icons8.com</string>
 				<key>runningsubtext</key>
 				<string>Searching...</string>
 				<key>script</key>
-				<string>./index.js `iconv -f UTF8-MAC&lt;&lt;&lt;$1`</string>
+				<string></string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -63,7 +63,7 @@ Icon by https://icons8.com</string>
 				<key>title</key>
 				<string>Monitor a Stop</string>
 				<key>type</key>
-				<integer>0</integer>
+				<integer>8</integer>
 				<key>withspace</key>
 				<true/>
 			</dict>


### PR DESCRIPTION
Fix an issue where the workflow would not allow to search for stations
containing umlauts.

As discussed in http://www.alfredforum.com/topic/2015-encoding-issue/,
alfred uses NSTask internally, which transforms Unicode characters into
their "Normalization Form Canonical Decomposition", meaning that
characters like "ü" get decompositioned into their equivalent
representation with "u¨"

Using iconv we can transform these characters back into their NFC
representation (one single character), which then allows everything to
work properly.

In order to use iconv to transform the args, the workflow changed from
"invoke external script" to "run bash script", which again starts our
node application
